### PR TITLE
Support `BytesLoader` for svg assets

### DIFF
--- a/examples/tailwind_elements_playground/.gitignore
+++ b/examples/tailwind_elements_playground/.gitignore
@@ -42,4 +42,5 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
-assets/
+assets/*.svg.vec
+assets/*.svg

--- a/examples/tailwind_elements_playground/pubspec.lock
+++ b/examples/tailwind_elements_playground/pubspec.lock
@@ -512,7 +512,7 @@ packages:
     source: hosted
     version: "1.3.2"
   vector_graphics:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: vector_graphics
       sha256: "0f0c746dd2d6254a0057218ff980fc7f5670fd0fcf5e4db38a490d31eed4ad43"

--- a/examples/tailwind_elements_playground/pubspec.yaml
+++ b/examples/tailwind_elements_playground/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   flutter_svg: ^2.0.9
+  vector_graphics: ^1.1.9+1
 
 dev_dependencies:
   flutter_test:

--- a/lib/widgets/checkbox.dart
+++ b/lib/widgets/checkbox.dart
@@ -35,7 +35,7 @@ class TwCheckbox extends TwStatefulWidget {
   final CssAbsoluteUnit tapTargetSize;
 
   /// Custom SVG asset to use for the checkmark icon.
-  final SvgAssetLoader? checkmarkSvg;
+  final BytesLoader? checkmarkSvg;
 
   const TwCheckbox({
     required this.initialValue,

--- a/lib/widgets/icon.dart
+++ b/lib/widgets/icon.dart
@@ -11,7 +11,7 @@ import 'package:tailwind_elements/widgets/style/style.dart';
 @immutable
 class TwIcon extends StatelessWidget {
   final IconData? icon;
-  final SvgAssetLoader? svg;
+  final BytesLoader? svg;
   final TwStyle style;
 
   const TwIcon.icon({

--- a/lib/widgets/icon.dart
+++ b/lib/widgets/icon.dart
@@ -10,8 +10,14 @@ import 'package:tailwind_elements/widgets/style/style.dart';
 /// be treated as a null value.
 @immutable
 class TwIcon extends StatelessWidget {
+  /// The icon data to display, when not using SVG graphics.
   final IconData? icon;
+
+  /// The SVG graphic data to display, when not using an [IconData].
   final BytesLoader? svg;
+
+  /// Tailwind styling properties, supports only [textColor], and [CssAbsoluteUnit] values for
+  /// [width] and [height].
   final TwStyle style;
 
   const TwIcon.icon({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   meta: ^1.10.0
   path: ^1.8.3
   source_gen: ^1.5.0
+  vector_graphics: ^1.1.9+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Allows using precompiled & optimized `svg.vec` from [vector_graphics](https://pub.dev/packages/vector_graphics)