### PR TITLE
Change dispose order for animation controller

### DIFF
--- a/examples/breeze_ui_playground/lib/main.dart
+++ b/examples/breeze_ui_playground/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:breeze_ui/base.dart';
 import 'package:breeze_ui/widgets.dart';
 import 'package:breeze_ui_playground/tailwind_config.dart';
 import 'package:flutter/material.dart';
-import 'package:vector_graphics/vector_graphics.dart';
 
 // ignore_for_file: avoid_print
 void main() {
@@ -56,9 +55,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                     TwCheckbox(
                       value: toggled,
                       isTristate: true,
-                      checkedIcon: const IconDataSvg(
-                        AssetBytesLoader('assets/checkmark.svg.vec'),
-                      ),
+                      checkedIcon: const IconDataFont(Icons.check),
                       style: const TwStyle(
                         backgroundColor: bg_indigo_200,
                         transition: transition_all,
@@ -77,9 +74,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                     TwCheckbox(
                       value: null,
                       isTristate: true,
-                      checkedIcon: const IconDataSvg(
-                        AssetBytesLoader('assets/checkmark.svg.vec'),
-                      ),
+                      checkedIcon: const IconDataFont(Icons.check),
                       style: const TwStyle(
                         backgroundColor: bg_indigo_200,
                         transition: transition_all,
@@ -98,9 +93,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                     TwCheckbox(
                       value: toggled,
                       isToggleable: false,
-                      checkedIcon: const IconDataSvg(
-                        AssetBytesLoader('assets/checkmark.svg.vec'),
-                      ),
+                      checkedIcon: const IconDataFont(Icons.check),
                       style: const TwStyle(
                         backgroundColor: bg_indigo_200,
                         transition: transition_all,
@@ -389,11 +382,6 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                     ),
                     const TwIcon(
                       icon: IconDataFont(Icons.check),
-                    ),
-                    const TwIcon(
-                      icon: IconDataSvg(
-                        AssetBytesLoader('assets/checkmark.svg.vec'),
-                      ),
                     ),
                   ],
                 ),

--- a/lib/widgets/div.dart
+++ b/lib/widgets/div.dart
@@ -96,4 +96,10 @@ class _TwDiv extends TwAnimatedMaterialState<TwDiv>
 
   @override
   TickerProvider getTickerProvider() => this;
+
+  @override
+  void dispose() {
+    disposeController();
+    super.dispose();
+  }
 }

--- a/lib/widgets/interactive/button.dart
+++ b/lib/widgets/interactive/button.dart
@@ -110,4 +110,10 @@ class _TwButtonState extends TwAnimatedMaterialState<TwButton>
 
   @override
   TickerProvider getTickerProvider() => this;
+
+  @override
+  void dispose() {
+    disposeController();
+    super.dispose();
+  }
 }

--- a/lib/widgets/interactive/checkbox.dart
+++ b/lib/widgets/interactive/checkbox.dart
@@ -169,4 +169,10 @@ class _CheckboxState extends TwAnimatedMaterialState<TwCheckbox>
 
   @override
   TickerProvider getTickerProvider() => this;
+
+  @override
+  void dispose() {
+    disposeController();
+    super.dispose();
+  }
 }

--- a/lib/widgets/interactive/switch.dart
+++ b/lib/widgets/interactive/switch.dart
@@ -182,6 +182,7 @@ class _SwitchTrackState extends TwAnimatedMaterialState<TwSwitch>
   void dispose() {
     thumbController?.removeListener(handleAnimationControllerUpdate);
     thumbController?.dispose();
+    disposeController();
     super.dispose();
   }
 

--- a/lib/widgets/state/animated_material_state.dart
+++ b/lib/widgets/state/animated_material_state.dart
@@ -327,12 +327,11 @@ abstract class TwAnimatedMaterialState<T extends TwStatefulWidget>
     }
   }
 
-  @override
-  void dispose() {
+  @protected
+  void disposeController() {
     animationController?.removeListener(handleAnimationControllerUpdate);
     animationController?.dispose();
     animationCurve?.dispose();
-    super.dispose();
   }
 
   TwStyle? getAnimatedStyle() {

--- a/lib/widgets/state/animated_material_state.dart
+++ b/lib/widgets/state/animated_material_state.dart
@@ -327,6 +327,11 @@ abstract class TwAnimatedMaterialState<T extends TwStatefulWidget>
     }
   }
 
+  /// This method disposes the animation controller and the underlying ticker
+  /// from the ticker provider mixin.
+  ///
+  /// IMPORTANT: It is necessary for this method to be called in any subclassed
+  /// state as the first part of the [dispose] method.
   @protected
   void disposeController() {
     animationController?.removeListener(handleAnimationControllerUpdate);


### PR DESCRIPTION
Potentially fixes issue where the TickerProvider's dispose() method was being called before the animation controller was disposed, which causes an exception when the animated widget is disposed mid-animation:

```
        ErrorSummary('$this was disposed with an active Ticker.'),
        ErrorDescription(
          '$runtimeType created a Ticker via its SingleTickerProviderStateMixin, but at the time '
          'dispose() was called on the mixin, that Ticker was still active. The Ticker must '
          'be disposed before calling super.dispose().',
        ),
        ErrorHint(
          'Tickers used by AnimationControllers '
          'should be disposed by calling dispose() on the AnimationController itself. '
          'Otherwise, the ticker will leak.',
        ),
```

This change makes sure that `animationController?.dispose()` is called before the `super.dispose()` to the TickerProvider mixin is called.