### PR TITLE
Rename Div->TwDiv and TwDiv->TwDivInteractive

### DIFF
--- a/examples/breeze_ui_playground/justfile
+++ b/examples/breeze_ui_playground/justfile
@@ -1,0 +1,14 @@
+clean:
+    dart run build_runner clean
+
+get:
+    flutter pub get
+
+format:
+    dart format $(find lib -name "*.dart" -not \( -name "*.*freezed.dart" -o -name "*.*g.dart" -o -name "*generated.dart" \) )
+
+lint: format
+    dart analyze --fatal-infos --fatal-warnings
+
+gen:
+    dart run build_runner build --delete-conflicting-outputs

--- a/examples/breeze_ui_playground/lib/main.dart
+++ b/examples/breeze_ui_playground/lib/main.dart
@@ -31,7 +31,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
         useMaterial3: true,
       ),
       home: Material(
-        child: Div(
+        child: TwDiv(
           style: const TwStyle(
             height: h_96,
             backgroundColor: bg_slate_50,
@@ -129,7 +129,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                         onToggled: (final bool? value) {
                           print('switch toggled: $value');
                         },
-                        thumb: const TwDiv(
+                        thumb: const TwDivInteractive(
                           style: TwStyle(
                             backgroundColor: bg_white,
                             transition: transition_all,
@@ -165,7 +165,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                       onToggled: (final bool? value) {
                         print('switch toggled: $value');
                       },
-                      thumb: const Div(
+                      thumb: const TwDiv(
                         style: TwStyle(
                           backgroundColor: bg_white,
                           width: w_5,
@@ -179,7 +179,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                 TwRow(
                   scrollable: true,
                   children: [
-                    TwDiv(
+                    TwDivInteractive(
                       style: TwStyle(
                         width: w_frac_1_3,
                         height: toggled ? h_64 : h_36,
@@ -187,7 +187,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                         transition: transition_all,
                       ),
                     ),
-                    TwDiv(
+                    TwDivInteractive(
                       style: TwStyle(
                         width: w_frac_1_3,
                         height: toggled ? h_64 : h_36,
@@ -195,7 +195,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                         transition: transition_all,
                       ),
                     ),
-                    TwDiv(
+                    TwDivInteractive(
                       style: TwStyle(
                         width: w_frac_1_3,
                         height: toggled ? h_64 : h_36,
@@ -208,7 +208,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                       child: TwRow(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          const TwDiv(
+                          const TwDivInteractive(
                             style: TwStyle(
                               width: w_frac_1_2,
                               height: h_frac_1_2,
@@ -219,7 +219,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                               backgroundColor: bg_red_400,
                             ),
                           ),
-                          TwDiv(
+                          TwDivInteractive(
                             alignment: Alignment.topLeft,
                             style: TwStyle(
                               width: w_frac_1_2,
@@ -229,7 +229,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                             ),
                             child: const TwColumn(
                               children: [
-                                TwDiv(
+                                TwDivInteractive(
                                   style: TwStyle(
                                     width: w_frac_1_2,
                                     height: h_frac_1_3,
@@ -248,7 +248,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                 TwRow(
                   children: [
                     TwMaterialStatesGroup(
-                      child: TwDiv(
+                      child: TwDivInteractive(
                         enableInputDetectors: true,
                         isDraggable: true,
                         style: TwStyle(
@@ -271,7 +271,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                         dragged: const TwStyle(
                           backgroundColor: bg_blue_900,
                         ),
-                        child: TwDiv(
+                        child: TwDivInteractive(
                           style: TwStyle(
                             width: toggled ? w_frac_1_2 : w_64,
                             height: toggled ? h_4 : h_frac_1_3,
@@ -385,7 +385,7 @@ class _BreezeUIPlaygroundState extends State<BreezeUIPlayground> {
                     ),
                   ],
                 ),
-                const Div(
+                const TwDiv(
                   style: TwStyle(
                     width: w_screen,
                     height: h_screen,

--- a/examples/breeze_ui_playground/pubspec.lock
+++ b/examples/breeze_ui_playground/pubspec.lock
@@ -47,7 +47,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   build:
     dependency: transitive
     description:
@@ -306,6 +306,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -326,26 +350,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -366,10 +390,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_parsing:
     dependency: transitive
     description:
@@ -543,6 +567,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,11 @@
+clean:
+    dart run build_runner clean
+
+get:
+    flutter pub get
+
+format:
+    dart format $(find lib -name "*.dart" -not \( -name "*.*freezed.dart" -o -name "*.*g.dart" -o -name "*generated.dart" \) )
+
+lint: format
+    dart analyze --fatal-infos --fatal-warnings

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -1,5 +1,5 @@
 export 'package:breeze_ui/config/options/units.dart';
-export 'package:breeze_ui/widgets/div.dart';
+export 'package:breeze_ui/widgets/div_interactive.dart';
 export 'package:breeze_ui/widgets/inherited/parent_constraints_data.dart';
 export 'package:breeze_ui/widgets/inherited/parent_material_states_data.dart';
 export 'package:breeze_ui/widgets/interactive/button.dart';

--- a/lib/widgets/div_interactive.dart
+++ b/lib/widgets/div_interactive.dart
@@ -6,12 +6,12 @@ import 'package:breeze_ui/widgets/stateless/div.dart';
 import 'package:breeze_ui/widgets/style/style.dart';
 import 'package:flutter/material.dart';
 
-/// A [Div] widget wrapper with support for Tailwind styled properties
+/// A [TwDiv] widget wrapper with support for Tailwind styled properties
 /// and animated property transitions.
 ///
 /// A [TwMaterialStatesGroup] may be used to reuse the same animation controller
 /// for multiple [TwStatefulWidget]s that support animations.
-class TwDiv extends TwStatefulWidget {
+class TwDivInteractive extends TwStatefulWidget {
   // Passthrough [Container] properties
   final Widget? child;
   final AlignmentGeometry? alignment;
@@ -19,7 +19,7 @@ class TwDiv extends TwStatefulWidget {
   final Matrix4? transform;
   final AlignmentGeometry? transformAlignment;
 
-  const TwDiv({
+  const TwDivInteractive({
     this.child,
     // Passthrough [Container] properties
     this.alignment = Alignment.topLeft,
@@ -64,17 +64,17 @@ class TwDiv extends TwStatefulWidget {
   });
 
   @override
-  State createState() => _TwDiv();
+  State createState() => _TwDivInteractive();
 }
 
-class _TwDiv extends TwAnimatedMaterialState<TwDiv>
+class _TwDivInteractive extends TwAnimatedMaterialState<TwDivInteractive>
     with SingleTickerProviderStateMixin {
   @override
   Widget build(final BuildContext context) {
     final currentStyle = getCurrentStyle(currentStates);
     final animatedStyle = currentStyle.merge(getAnimatedStyle());
 
-    final div = Div(
+    final div = TwDiv(
       style: animatedStyle,
       staticConstraints: currentStyle.toConstraints(),
       parentControlsOpacity: true,

--- a/lib/widgets/interactive/button.dart
+++ b/lib/widgets/interactive/button.dart
@@ -72,14 +72,14 @@ class TwButton extends TwStatefulWidget {
 
 class _TwButtonState extends TwAnimatedMaterialState<TwButton>
     with SingleTickerProviderStateMixin {
-  /// Wrap the button by extending [TwStatefulWidget] and using a [Div] for simplicity of applying
+  /// Wrap the button by extending [TwStatefulWidget] and using a [TwDiv] for simplicity of applying
   /// styles with support for animated transitions.
   @override
   Widget build(final BuildContext context) {
     final currentStyle = getCurrentStyle(currentStates);
     final animatedStyle = currentStyle.merge(getAnimatedStyle());
 
-    final div = Div(
+    final div = TwDiv(
       style: animatedStyle,
       staticConstraints: currentStyle.toConstraints(),
       parentControlsOpacity: true,

--- a/lib/widgets/interactive/checkbox.dart
+++ b/lib/widgets/interactive/checkbox.dart
@@ -142,7 +142,7 @@ class _CheckboxState extends TwAnimatedMaterialState<TwCheckbox>
           )
         : null;
 
-    final div = Div(
+    final div = TwDiv(
       style: animatedStyle,
       staticConstraints: currentStyle.toConstraints(),
       parentControlsOpacity: true,

--- a/lib/widgets/interactive/switch.dart
+++ b/lib/widgets/interactive/switch.dart
@@ -195,7 +195,7 @@ class _SwitchTrackState extends TwAnimatedMaterialState<TwSwitch>
       alignment: getAnimatedAlignment() ?? Alignment.centerLeft,
       child: widget.thumb,
     );
-    final div = Div(
+    final div = TwDiv(
       style: animatedStyle,
       staticConstraints: currentStyle.toConstraints(),
       parentControlsOpacity: true,

--- a/lib/widgets/stateless/div.dart
+++ b/lib/widgets/stateless/div.dart
@@ -8,7 +8,7 @@ import 'package:breeze_ui/widgets/style/style.dart';
 import 'package:flutter/material.dart';
 
 /// A [Container]-like widget with support for Tailwind styled properties.
-class Div extends TwStatelessWidget {
+class TwDiv extends TwStatelessWidget {
   // Passthrough [Container] properties
   final Widget? child;
   final AlignmentGeometry? alignment;
@@ -20,7 +20,7 @@ class Div extends TwStatelessWidget {
   /// by the parent widget.
   final bool? parentControlsOpacity;
 
-  const Div({
+  const TwDiv({
     required super.style,
     this.child,
     this.alignment = Alignment.topLeft,

--- a/lib/widgets/stateless/icon.dart
+++ b/lib/widgets/stateless/icon.dart
@@ -30,7 +30,7 @@ class IconDataSvg implements TwIconData {
 }
 
 /// A widget representing an [Icon] or [SvgPicture] with support for Tailwind styled properties.
-/// The icon is rendered as a child of a [Div] widget for full styling support (meaning relative
+/// The icon is rendered as a child of a [TwDiv] widget for full styling support (meaning relative
 /// percent based sizing constraints will work).
 ///
 /// If a [style] is not provided, the [defaultIconStyle] will be used: a black icon with width and
@@ -54,7 +54,7 @@ class TwIcon extends TwStatelessWidget {
   /// The icon data to use for display. Can be either an [IconData] or svg [BytesLoader].
   final TwIconData icon;
 
-  /// The alignment of the icon within the [Div] widget. Defaults to [Alignment.center].
+  /// The alignment of the icon within the [TwDiv] widget. Defaults to [Alignment.center].
   final Alignment? alignment;
 
   /// Whether the icon should expand to fill the available space. This is accomplished by wrapping
@@ -108,7 +108,7 @@ class TwIcon extends TwStatelessWidget {
         ),
     };
 
-    return Div(
+    return TwDiv(
       style: style,
       staticConstraints: staticConstraints,
       parentControlsOpacity: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: breeze_ui
 description: "Flutter UI library that supports TailwindCSS options and configurations via code generation."
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/SquintInc/breeze_ui
 
 environment:


### PR DESCRIPTION
`Div` was causing some confusion. Prefer to rename the basic div to `TwDiv` so that people can rely on autocomplete more easily, and rename the interactive/animateable div to `TwDivInteractive`