### PR TITLE
Pin tailwind JSON configs from upstream to v3.4.3

### DIFF
--- a/lib/config/builder/tailwind_config_builder.dart
+++ b/lib/config/builder/tailwind_config_builder.dart
@@ -9,9 +9,9 @@ import 'package:path/path.dart' as path;
 import 'package:source_gen/source_gen.dart';
 
 const String configFullJsUrl =
-    'https://raw.githubusercontent.com/tailwindlabs/tailwindcss/master/stubs/config.full.js';
+    'https://raw.githubusercontent.com/tailwindlabs/tailwindcss/v3.4.3/stubs/config.full.js';
 const String configColorsJsUrl =
-    'https://raw.githubusercontent.com/tailwindlabs/tailwindcss/master/src/public/colors.js';
+    'https://raw.githubusercontent.com/tailwindlabs/tailwindcss/v3.4.3/src/public/colors.js';
 const additionalFunctionsPackage =
     'package:breeze_ui/config/builder/config_functions.template.dart';
 const templateRemovePriorIdentifier =


### PR DESCRIPTION
Since tailwind will be releasing v4.0 sometime in the future with an entirely different underlying stack to generate tailwind colors, going to pin our current code generation setup to use tailwind v3